### PR TITLE
Fix config.py indentation error and update OpenAPI spec

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -200,14 +200,14 @@ class Config:
                 format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
                 datefmt="%Y-%m-%d %H:%M:%S"
             )
-        
+
         # Ensure root logger level is set (child loggers inherit this)
         logging.root.setLevel(logging_level)
 
         # Suppress noisy HTTP-related loggers
-        logging.getLogger("httpcore").setLevel(logging.WARNING)
-        logging.getLogger("httpx").setLevel(logging.WARNING)
-        
+        logging.getLogger("httpcore").setLevel(logging.WARNING)  
+        logging.getLogger("httpx").setLevel(logging.WARNING)  
+
         # Suppress Werkzeug request logs (set to WARNING to reduce noise)
         werkzeug_logger = logging.getLogger("werkzeug")
         werkzeug_logger.setLevel(logging.WARNING)


### PR DESCRIPTION
- Fix indentation error in configure_logging() else block (Python < 3.8 path)
- Update OpenAPI spec to match actual API paths:
  - Fix paths: /api/{runbook} -> /api/runbooks/{runbook}
  - Add /api/runbooks/{runbook}/validate and /execute endpoints
  - Add security requirements (bearerAuth) to all endpoints
  - Fix curl examples to use correct paths
  - Add security scheme definition
- Fix validate/execute endpoints to use correct API paths with suffixes